### PR TITLE
Making selenium tests run with es6 code

### DIFF
--- a/Test_Resources/tasks/test.js
+++ b/Test_Resources/tasks/test.js
@@ -12,8 +12,9 @@ module.exports = function (gulp, context) {
     var glob = require('glob');
     var path = require('path');
     var _ = require('underscore');
+    var babel = require("babel-core/register");
 
-    function handleError(err) {
+  function handleError(err) {
         gutil.log(err.toString());
         this.emit('end'); //jshint ignore:line
     }
@@ -44,6 +45,9 @@ module.exports = function (gulp, context) {
 
         return gulp.src(directories.test + '/test.js')
             .pipe(mocha({
+                "compilers": {
+                  "js": babel
+                },
                 reporter: reporter,
                 timeout: 500000
             }))

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -17,6 +17,7 @@ module.exports = function testTasks(gulp, context) {
   var glob = require("glob");
   var path = require("path");
   var R = require("ramda");
+  var babel = require("babel-core/register");
   var logger = context.logger;
   var COVERAGE_VAR = "__cpmCoverage__";
 
@@ -56,6 +57,9 @@ module.exports = function testTasks(gulp, context) {
 
     return gulp.src(path.resolve(process.cwd(), directories.test + "/test.js"), {"read": false})
       .pipe(mocha({
+        "compilers": {
+          "js": babel
+        },
         "reporter": reporter,
         "timeout": 600000
       }))


### PR DESCRIPTION
Had to add the babel compiler to the mocha test runner. Wasn't sure which test.js was the correct one to modify, so this commit has both ~/tasks/test.js & ~/Test_Resources/tasks/test.js

I don't think it will impact older tests, but I'll leave it up to you whether you merge this in, or make it somehow configurable. In the meantime Vish is running this code against the ES5 master branch so that should give it somewhat of a smoke test.